### PR TITLE
CFE-812: Rename SKU component to NostoSkuOptions

### DIFF
--- a/src/components/NostoSkuOptions.ts
+++ b/src/components/NostoSkuOptions.ts
@@ -1,6 +1,6 @@
 import { SkuEventDetailProps, SkuEventProps } from "@/components/types"
 
-export class NostoSkuOptionGroup extends HTMLElement {
+export class NostoSkuOptions extends HTMLElement {
   private _optionTypeToSkuIds: Record<string, string[]>
 
   constructor() {
@@ -135,7 +135,7 @@ export class NostoSkuOptionGroup extends HTMLElement {
 }
 
 try {
-  customElements.define("nosto-sku-option-group", NostoSkuOptionGroup)
+  customElements.define("nosto-sku-options", NostoSkuOptions)
 } catch (e) {
   console.error(e)
 }

--- a/test/components/NostoSkuOptions.spec.ts
+++ b/test/components/NostoSkuOptions.spec.ts
@@ -1,16 +1,16 @@
 import { describe, it, beforeEach, expect } from "vitest"
 import { NostoProduct } from "@/components/NostoProduct"
-import { NostoSkuOptionGroup } from "@/components/NostoSkuOptionGroup"
+import { NostoSkuOptions } from "@/components/NostoSkuOptions"
 
 describe("swatch side effects", () => {
   let nostoProduct: NostoProduct
-  let firstNostoSkuOptionGroup: NostoSkuOptionGroup
-  let secondNostoSkuOptionGroup: NostoSkuOptionGroup
+  let firstNostoSkuOptions: NostoSkuOptions
+  let secondNostoSkuOptions: NostoSkuOptions
 
   beforeEach(() => {
     nostoProduct = new NostoProduct()
-    firstNostoSkuOptionGroup = new NostoSkuOptionGroup()
-    secondNostoSkuOptionGroup = new NostoSkuOptionGroup()
+    firstNostoSkuOptions = new NostoSkuOptions()
+    secondNostoSkuOptions = new NostoSkuOptions()
     document.body.innerHTML = ""
     loadSkuContent()
   })
@@ -20,23 +20,23 @@ describe("swatch side effects", () => {
     nostoProduct.setAttribute("product-id", "123")
     nostoProduct.setAttribute("reco-id", "789")
 
-    firstNostoSkuOptionGroup.innerHTML = `
+    firstNostoSkuOptions.innerHTML = `
         <span n-option n-skus="123,145" selected>Black</span>
         <span n-option n-skus="223,234,245">White</span>
         <span n-option n-skus="334,345">Blue</span>
         `
 
-    secondNostoSkuOptionGroup.innerHTML = `
+    secondNostoSkuOptions.innerHTML = `
         <span n-option n-skus="123,223" selected>L</span>
         <span n-option n-skus="234,334">M</span>
         <span n-option n-skus="145,245,345">S</span>
     `
 
-    nostoProduct.appendChild(firstNostoSkuOptionGroup)
-    nostoProduct.appendChild(secondNostoSkuOptionGroup)
+    nostoProduct.appendChild(firstNostoSkuOptions)
+    nostoProduct.appendChild(secondNostoSkuOptions)
 
-    secondNostoSkuOptionGroup.connectedCallback()
-    firstNostoSkuOptionGroup.connectedCallback()
+    secondNostoSkuOptions.connectedCallback()
+    firstNostoSkuOptions.connectedCallback()
     nostoProduct.connectedCallback()
   }
 
@@ -64,15 +64,15 @@ describe("swatch side effects", () => {
   }
 
   it("should provide selection side effects on SKU selection", () => {
-    testClickedSku(firstNostoSkuOptionGroup, 2) // 223,234,245
-    testOtherSkusAfterClick(secondNostoSkuOptionGroup) // 123,223 & 234,334 & 145,245,345
+    testClickedSku(firstNostoSkuOptions, 2) // 223,234,245
+    testOtherSkusAfterClick(secondNostoSkuOptions) // 123,223 & 234,334 & 145,245,345
 
     expect(nostoProduct.selectedSkuId).toBe("223") // first matching SkuId is selected by default
   })
 
   it("should provide selection side effects on reverse SKU selection", () => {
-    testClickedSku(secondNostoSkuOptionGroup, 2) // 234,334
-    testOtherSkusAfterClick(firstNostoSkuOptionGroup) // 223,234,245
+    testClickedSku(secondNostoSkuOptions, 2) // 234,334
+    testOtherSkusAfterClick(firstNostoSkuOptions) // 223,234,245
 
     expect(nostoProduct.selectedSkuId).toBe("234") // first matching SkuId is selected by default
   })


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
Renames `NostoSkuOptionGroup` to `NostoSkuOptions`


## Related Jira ticket

<!--- Is there a Jira ticket for this change, if not - should there be? -->
<!--- If working on a new feature or change, please discuss it in an ticket first -->
<!--- If fixing a bug, there should be an ticket describing it with steps to reproduce -->
<!--- Please link to the ticket here: -->
https://nostosolutions.atlassian.net/browse/CFE-812

## Documentation

<!--- Is the change documented or should it be?, link the relevant wiki/confluence page here. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] Pull Request is properly described.
- [ ] The corresponding Jira ticket is updated.
- [ ] I have requested a review from at least one reviewer.
- [ ] The changes are tested
- [ ] I have checked my code for any possible security vulnerabilities

## Screenshots

<!--- If there is a visual element to the PR please share screenshots -->
<!--- Remember the saying "one picture says the same as a 1000 words". -->
