### PR TITLE
Move events to store

### DIFF
--- a/src/components/NostoProduct.ts
+++ b/src/components/NostoProduct.ts
@@ -10,7 +10,7 @@ export class NostoProduct extends HTMLElement {
 
   connectedCallback() {
     this.validate()
-    const store = createStore(this, this.productId, this.recoId)
+    const store = createStore(this)
     provideStore(this, store)
     store.listen("selectedSkuId", selectedSkuId => (this._selectedSkuId = selectedSkuId))
     this.registerSKUSelectors(store)
@@ -57,12 +57,12 @@ export class NostoProduct extends HTMLElement {
 
   private registerATCButtons({ addToCart, selectSkuId }: Store) {
     this.querySelectorAll("[n-atc]").forEach(element =>
-      element.addEventListener("click", () => {
+      element.addEventListener("click", async () => {
         const skuId = element.closest("[n-sku-id]")?.getAttribute("n-sku-id")
         if (skuId) {
           selectSkuId(skuId)
         }
-        addToCart()
+        await addToCart()
       })
     )
   }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,3 +1,4 @@
+import { NostoProduct } from "@/main"
 import { EVENT_TYPE_ADD_TO_CART_COMPLETE, triggerPlacementEvent } from "@/placement-events"
 import { intersectionOf } from "@/utils"
 
@@ -11,7 +12,8 @@ export type Events = Pick<State, "selectedSkuId" | "skuOptions">
 
 type Listener<T extends keyof Events> = (value: Events[T]) => void
 
-export function createStore(element: HTMLElement, productId: string, recoId: string) {
+export function createStore(element: NostoProduct) {
+  const { productId, recoId } = element
   const state: State = {
     selectedSkuId: undefined,
     skuOptions: {},

--- a/test/store/store.spec.ts
+++ b/test/store/store.spec.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect, vi } from "vitest"
 import { createStore, Events } from "@/store"
+import { NostoProduct } from "@/components/NostoProduct"
 
 describe("createStore", () => {
   function newStore(productId: string, recoId: string) {
-    const store = createStore(document.createElement("div"), productId, recoId)
+    const element = new NostoProduct()
+    element.setAttribute("product-id", productId)
+    element.setAttribute("reco-id", recoId)
+    const store = createStore(element)
     const events: Partial<Events> = {}
     store.listen("selectedSkuId", skuId => (events.selectedSkuId = skuId))
     store.listen("skuOptions", skuOptions => (events.skuOptions = skuOptions))


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
To make sure that the placement event is emitted when store.addToCart is called the event emission has been moved from NostoProduct to store level

## Related Jira ticket

<!--- Is there a Jira ticket for this change, if not - should there be? -->
<!--- If working on a new feature or change, please discuss it in an ticket first -->
<!--- If fixing a bug, there should be an ticket describing it with steps to reproduce -->
<!--- Please link to the ticket here: -->

## Documentation

<!--- Is the change documented or should it be?, link the relevant wiki/confluence page here. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] Pull Request is properly described.
- [ ] The corresponding Jira ticket is updated.
- [ ] I have requested a review from at least one reviewer.
- [ ] The changes are tested
- [ ] I have checked my code for any possible security vulnerabilities

## Screenshots

<!--- If there is a visual element to the PR please share screenshots -->
<!--- Remember the saying "one picture says the same as a 1000 words". -->
