### PR TITLE
Add additional placement events

### DIFF
--- a/src/placement-events.ts
+++ b/src/placement-events.ts
@@ -1,12 +1,14 @@
 type Events = {
-  complete: {
+  "atc:complete": {
     productId: string
     skuId: string
   }
-  "no-sku": {
+  "atc:no-sku-selected": {
     productId: string
   }
 }
+
+export type EventName = keyof Events
 
 export function triggerPlacementEvent<E extends keyof Events>(type: E, sourceElement: Element, detail: Events[E]) {
   const eventTarget = sourceElement.closest('.nosto_element[id]:not(.nosto_element[id=""])')
@@ -14,7 +16,7 @@ export function triggerPlacementEvent<E extends keyof Events>(type: E, sourceEle
     console.warn(`Unable to locate the wrapper placement to trigger ${type} event`)
     return
   }
-  const event = new CustomEvent(`nosto:atc:${type}`, {
+  const event = new CustomEvent(`nosto:${type}`, {
     bubbles: true,
     cancelable: true,
     detail

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -24,16 +24,16 @@ export function createStore(element: NostoProduct) {
 
   async function addToCart() {
     if (state.selectedSkuId) {
-      if (window.Nosto && typeof window.Nosto.addSkuToCart === "function") {
+      if (typeof window.Nosto?.addSkuToCart === "function") {
         const skuId = state.selectedSkuId
         await window.Nosto.addSkuToCart({ productId, skuId }, recoId, 1)
-        triggerPlacementEvent("complete", element, {
+        triggerPlacementEvent("atc:complete", element, {
           productId,
           skuId
         })
       }
     } else {
-      triggerPlacementEvent("no-sku", element, { productId })
+      triggerPlacementEvent("atc:no-sku-selected", element, { productId })
     }
   }
 

--- a/test/components/NostoProduct.spec.ts
+++ b/test/components/NostoProduct.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest"
 import { NostoProduct } from "../../src/components/NostoProduct"
+import { EventName } from "@/placement-events"
 
 describe("NostoProduct", () => {
   let element: NostoProduct
@@ -62,10 +63,10 @@ describe("NostoProduct", () => {
       )
     }
 
-    async function waitForPlacementEvent(eventType: string) {
+    async function waitForPlacementEvent(eventType: EventName) {
       return new Promise(resolve => {
         const placement = document.querySelector<HTMLElement>(`[id="${DIV_ID}"]`)
-        placement!.addEventListener(eventType, (event: Event) => resolve((event as CustomEvent).detail))
+        placement!.addEventListener(`nosto:${eventType}`, (event: Event) => resolve((event as CustomEvent).detail))
       })
     }
 
@@ -81,7 +82,7 @@ describe("NostoProduct", () => {
 
     async function checkAddToCartCompleteEvent(atcElement: HTMLElement) {
       atcElement!.click()
-      const detail = await waitForPlacementEvent("nosto:atc:complete")
+      const detail = await waitForPlacementEvent("atc:complete")
 
       expect(window.Nosto!.addSkuToCart).toHaveBeenCalledWith(
         { productId: PROD_ID, skuId: element.selectedSkuId },
@@ -119,7 +120,7 @@ describe("NostoProduct", () => {
       placementElement.appendChild(element)
       document.body.appendChild(placementElement)
 
-      const detail = waitForPlacementEvent("nosto:atc:no-sku")
+      const detail = waitForPlacementEvent("atc:no-sku-selected")
       element.querySelector<HTMLElement>("[n-atc]")!.click()
       expect(await detail).toEqual({ productId: PROD_ID })
     })


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
Emits a placement level event for ATC clicks without a SKU being defined for externally managed side effects

## Related Jira ticket

<!--- Is there a Jira ticket for this change, if not - should there be? -->
<!--- If working on a new feature or change, please discuss it in an ticket first -->
<!--- If fixing a bug, there should be an ticket describing it with steps to reproduce -->
<!--- Please link to the ticket here: -->
https://nostosolutions.atlassian.net/browse/CFE-893

## Documentation

<!--- Is the change documented or should it be?, link the relevant wiki/confluence page here. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] Pull Request is properly described.
- [ ] The corresponding Jira ticket is updated.
- [ ] I have requested a review from at least one reviewer.
- [ ] The changes are tested
- [ ] I have checked my code for any possible security vulnerabilities

## Screenshots

<!--- If there is a visual element to the PR please share screenshots -->
<!--- Remember the saying "one picture says the same as a 1000 words". -->
