### PR TITLE
Register custom element classes via legacy decorators (3rd)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         run: npm ci
 
       - name: Build project
-        run: npm run build:ci
+        run: npm run build
 
       - name: Run tests
         run: npm test

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   },
   "scripts": {
     "dev": "npm run build && vite",
-    "build": "tsc && vite build --mode development",
-    "build:ci": "tsc && vite build",
+    "build": "tsc && vite build",
+    "build:dev": "tsc && vite build --mode development",
     "preview": "vite preview",
     "lint": "eslint",
     "test": "vitest --run --silent"

--- a/src/components/NostoProduct.ts
+++ b/src/components/NostoProduct.ts
@@ -1,8 +1,14 @@
 import { createStore, provideStore, Store } from "../store"
+import { customElement, attribute } from "./decorators"
 
+@customElement("nosto-product")
 export class NostoProduct extends HTMLElement {
-  static observedAttributes = ["product-id", "reco-id"]
   private _selectedSkuId: string | undefined
+
+  @attribute("product-id")
+  productId!: string
+  @attribute("reco-id")
+  recoId!: string
 
   constructor() {
     super()
@@ -21,24 +27,16 @@ export class NostoProduct extends HTMLElement {
     this.registerATCButtons(store)
   }
 
-  get productId() {
-    return this.getAttribute("product-id")!
-  }
-
   get selectedSkuId() {
     return this._selectedSkuId
   }
 
-  get recoId() {
-    return this.getAttribute("reco-id")!
-  }
-
   private validate() {
-    if (!this.getAttribute("product-id")) {
+    if (!this.productId) {
       throw new Error("Product ID is required.")
     }
 
-    if (!this.getAttribute("reco-id")) {
+    if (!this.recoId) {
       throw new Error("Slot ID is required.")
     }
   }
@@ -69,10 +67,4 @@ export class NostoProduct extends HTMLElement {
       })
     )
   }
-}
-
-try {
-  customElements.define("nosto-product", NostoProduct)
-} catch (e) {
-  console.error(e)
 }

--- a/src/components/NostoShopify.ts
+++ b/src/components/NostoShopify.ts
@@ -1,6 +1,11 @@
 import { migrateToShopifyMarket } from "@/store/actions"
+import { customElement, attribute } from "./decorators"
 
+@customElement("nosto-shopify")
 export class NostoShopify extends HTMLElement {
+  @attribute("markets")
+  markets!: string
+
   constructor() {
     super()
   }
@@ -14,10 +19,4 @@ export class NostoShopify extends HTMLElement {
       migrateToShopifyMarket(campaignId)
     }
   }
-}
-
-try {
-  customElements.define("nosto-shopify", NostoShopify)
-} catch (e) {
-  console.error(e)
 }

--- a/src/components/NostoSkuOptions.ts
+++ b/src/components/NostoSkuOptions.ts
@@ -1,11 +1,16 @@
 import { intersectionOf } from "@/utils"
 import { injectStore, Store } from "../store"
+import { customElement, attribute } from "./decorators"
 
 function getSkus(element: Element) {
   return (element.getAttribute("n-skus") || "").split(",")
 }
 
+@customElement("nosto-sku-options")
 export class NostoSkuOptions extends HTMLElement {
+  @attribute("name")
+  name!: string
+
   constructor() {
     super()
   }
@@ -15,12 +20,8 @@ export class NostoSkuOptions extends HTMLElement {
     injectStore(this, this.init.bind(this))
   }
 
-  get name() {
-    return this.getAttribute("name")!
-  }
-
   private validate() {
-    if (!this.getAttribute("name")) {
+    if (!this.name) {
       throw new Error("Name is required.")
     }
   }
@@ -77,10 +78,4 @@ export class NostoSkuOptions extends HTMLElement {
       })
     })
   }
-}
-
-try {
-  customElements.define("nosto-sku-options", NostoSkuOptions)
-} catch (e) {
-  console.error(e)
 }

--- a/src/components/decorators.ts
+++ b/src/components/decorators.ts
@@ -1,0 +1,25 @@
+export function customElement(tagName: string) {
+  return function (constructor: CustomElementConstructor) {
+    if (!window.customElements.get(tagName)) {
+      window.customElements.define(tagName, constructor)
+    }
+  }
+}
+
+export function attribute(attrName: string) {
+  return function (prototype: HTMLElement, propertyKey: string) {
+    const constructor = prototype.constructor as { observedAttributes?: string[] }
+    if (!constructor.observedAttributes) {
+      constructor.observedAttributes = []
+    }
+    constructor.observedAttributes.push(attrName)
+
+    Object.defineProperty(prototype, propertyKey, {
+      get() {
+        return this.getAttribute(attrName)
+      },
+      enumerable: true,
+      configurable: true
+    })
+  }
+}

--- a/test/components/NostoProduct.spec.ts
+++ b/test/components/NostoProduct.spec.ts
@@ -19,6 +19,7 @@ describe("NostoProduct", () => {
     })
 
     it("should have observed attributes", () => {
+      // @ts-expect-error added via decorator
       expect(NostoProduct.observedAttributes).toEqual(["product-id", "reco-id"])
     })
 

--- a/test/components/decorators.spec.ts
+++ b/test/components/decorators.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from "vitest"
+import { customElement } from "../../src/components/decorators"
+
+describe("customElement", () => {
+  it("should define a custom element if not already defined", () => {
+    const tagName = "my-element"
+    const constructor = class extends HTMLElement {}
+
+    // Mock the customElements registry
+    const defineSpy = vi.spyOn(window.customElements, "define")
+    const getSpy = vi.spyOn(window.customElements, "get").mockReturnValue(undefined)
+
+    customElement(tagName)(constructor)
+
+    expect(getSpy).toHaveBeenCalledWith(tagName)
+    expect(defineSpy).toHaveBeenCalledWith(tagName, constructor)
+
+    // Restore the original implementation
+    defineSpy.mockRestore()
+    getSpy.mockRestore()
+  })
+
+  it("should not redefine a custom element if already defined", () => {
+    const tagName = "my-element"
+    const constructor = class extends HTMLElement {}
+
+    // Mock the customElements registry
+    const defineSpy = vi.spyOn(window.customElements, "define")
+    const getSpy = vi.spyOn(window.customElements, "get").mockReturnValue(constructor)
+
+    customElement(tagName)(constructor)
+
+    expect(getSpy).toHaveBeenCalledWith(tagName)
+    expect(defineSpy).not.toHaveBeenCalled()
+
+    // Restore the original implementation
+    defineSpy.mockRestore()
+    getSpy.mockRestore()
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "useDefineForClassFields": true,
     "module": "ESNext",
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
+    "experimentalDecorators": true,
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
Add decorators to manipulate custom element declaratively
* register custom elements via customElement class decorator
* map abstract fields to attributes

## Related Jira ticket

<!--- Is there a Jira ticket for this change, if not - should there be? -->
<!--- If working on a new feature or change, please discuss it in an ticket first -->
<!--- If fixing a bug, there should be an ticket describing it with steps to reproduce -->
<!--- Please link to the ticket here: -->

## Documentation

<!--- Is the change documented or should it be?, link the relevant wiki/confluence page here. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] Pull Request is properly described.
- [ ] The corresponding Jira ticket is updated.
- [ ] I have requested a review from at least one reviewer.
- [ ] The changes are tested
- [ ] I have checked my code for any possible security vulnerabilities

## Screenshots

<!--- If there is a visual element to the PR please share screenshots -->
<!--- Remember the saying "one picture says the same as a 1000 words". -->
