### PR TITLE
Switch to legacy decorators

### DIFF
--- a/src/components/NostoProduct.ts
+++ b/src/components/NostoProduct.ts
@@ -1,18 +1,18 @@
 import { createStore, provideStore, Store } from "../store"
-import { attribute, customElement } from "./decorators"
+import { customElement } from "./decorators"
 
 @customElement("nosto-product")
-class NostoProduct extends HTMLElement {
+export class NostoProduct extends HTMLElement {
+  static attributes = {
+    productId: String,
+    recoId: String,
+    skuSelected: Boolean
+  }
+
   private _selectedSkuId: string | undefined
-
-  @attribute("product-id")
-  accessor productId!: string
-
-  @attribute("reco-id")
-  accessor recoId!: string
-
-  @attribute("sku-selected", Boolean)
-  accessor skuSelected!: boolean
+  productId!: string
+  recoId!: string
+  skuSelected!: boolean
 
   constructor() {
     super()
@@ -71,5 +71,3 @@ class NostoProduct extends HTMLElement {
     )
   }
 }
-
-export { NostoProduct }

--- a/src/components/NostoShopify.ts
+++ b/src/components/NostoShopify.ts
@@ -1,10 +1,13 @@
 import { migrateToShopifyMarket } from "@/store/actions"
-import { attribute, customElement } from "./decorators"
+import { customElement } from "./decorators"
 
 @customElement("nosto-shopify")
-class NostoShopify extends HTMLElement {
-  @attribute("markets", Boolean)
-  accessor markets!: boolean
+export class NostoShopify extends HTMLElement {
+  static attributes = {
+    markets: Boolean
+  }
+
+  markets!: boolean
 
   constructor() {
     super()
@@ -20,5 +23,3 @@ class NostoShopify extends HTMLElement {
     }
   }
 }
-
-export { NostoShopify }

--- a/src/components/NostoSkuOptions.ts
+++ b/src/components/NostoSkuOptions.ts
@@ -1,15 +1,18 @@
 import { intersectionOf } from "@/utils"
 import { injectStore, Store } from "../store"
-import { attribute, customElement } from "./decorators"
+import { customElement } from "./decorators"
 
 function getSkus(element: Element) {
   return (element.getAttribute("n-skus") || "").split(",")
 }
 
 @customElement("nosto-sku-options")
-class NostoSkuOptions extends HTMLElement {
-  @attribute("name")
-  accessor name!: string
+export class NostoSkuOptions extends HTMLElement {
+  static attributes = {
+    name: String
+  }
+
+  name!: string
 
   constructor() {
     super()
@@ -79,5 +82,3 @@ class NostoSkuOptions extends HTMLElement {
     })
   }
 }
-
-export { NostoSkuOptions }

--- a/test/components/decorators.spec.ts
+++ b/test/components/decorators.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { customElement, attribute } from "../../src/components/decorators"
+import { customElement } from "../../src/components/decorators"
 
 describe("customElement", () => {
   beforeEach(() => {
@@ -25,25 +25,5 @@ describe("customElement", () => {
 
     customElement(tagName)(constructor)
     expect(window.customElements.define).toHaveBeenCalledTimes(1)
-  })
-})
-
-@customElement("example-element")
-class Example extends HTMLElement {
-  @attribute("name")
-  accessor name!: string
-
-  @attribute("disabled", Boolean)
-  accessor disabled!: boolean
-}
-
-describe("attribute", () => {
-  it("should map attributes to properties", () => {
-    const example = new Example()
-    example.setAttribute("name", "John")
-    example.toggleAttribute("disabled", true)
-
-    expect(example.name).toBe("John")
-    expect(example.disabled).toBe(true)
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
+    "experimentalDecorators": true,
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
The ES decorator transpilation adds too much overhead to the bundle size

before

dist/main.es.js  15.25 kB │ gzip: 4.10 kB │ map: 19.96 kB
dist/main.cjs.js  11.52 kB │ gzip: 3.67 kB │ map: 19.11 kB

after

dist/main.es.js  7.35 kB │ gzip: 2.37 kB │ map: 18.45 kB
dist/main.cjs.js  5.69 kB │ gzip: 2.10 kB │ map: 17.64 kB

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->