### PR TITLE
commit-msg hook for conventional commit messages

### DIFF
--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -1,21 +1,9 @@
 #!/bin/sh
 #
-# An example hook script to check the commit log message.
-# Called by "git commit" with one argument, the name of the file
-# that has the commit message.  The hook should exit with non-zero
-# status after issuing an appropriate message if it wants to stop the
-# commit.  The hook is allowed to edit the commit message file.
-#
-# To enable this hook, rename this file to "commit-msg".
-
-# Uncomment the below to add a Signed-off-by line to the message.
-# Doing this in a hook is a bad idea in general, but the prepare-commit-msg
-# hook is more suited to it.
-#
-# SOB=$(git var GIT_AUTHOR_IDENT | sed -n 's/^\(.*>\).*$/Signed-off-by: \1/p')
-# grep -qs "^$SOB" "$1" || echo "$SOB" >> "$1"
-
-# This example catches duplicate Signed-off-by lines.
+# This hook checks if one of the commit messages in current branch contains a prefix of "fix" or "feat"
+# If not, it will print a warning message suggesting to include one before merging the PR
+# for automatic semantic versioning release.
+# for more info on commit message format, see https://www.conventionalcommits.org/en/v1.0.0/
 
 RED='\033[0;31m'
 NC='\033[0m'

--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -20,13 +20,11 @@
 RED='\033[0;31m'
 NC='\033[0m'
 
-TYPE='feat|fix'
-
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 MSG_HISTORY=$(git cherry -v main | cut -d ' ' -f 3-)
 
-PATTERN="^$TYPE\(.*\)?:"
+PATTERN="^fix|feat(\(.*\))?\!?:"
 
 if [ -z "$(grep -E -i "$PATTERN" "$1")" ]; then
 	for i in $MSG_HISTORY; do

--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -1,0 +1,40 @@
+#!/bin/sh
+#
+# An example hook script to check the commit log message.
+# Called by "git commit" with one argument, the name of the file
+# that has the commit message.  The hook should exit with non-zero
+# status after issuing an appropriate message if it wants to stop the
+# commit.  The hook is allowed to edit the commit message file.
+#
+# To enable this hook, rename this file to "commit-msg".
+
+# Uncomment the below to add a Signed-off-by line to the message.
+# Doing this in a hook is a bad idea in general, but the prepare-commit-msg
+# hook is more suited to it.
+#
+# SOB=$(git var GIT_AUTHOR_IDENT | sed -n 's/^\(.*>\).*$/Signed-off-by: \1/p')
+# grep -qs "^$SOB" "$1" || echo "$SOB" >> "$1"
+
+# This example catches duplicate Signed-off-by lines.
+
+RED='\033[0;31m'
+NC='\033[0m'
+
+TYPE='feat|fix'
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+MSG_HISTORY=$(git cherry -v main | cut -d ' ' -f 3-)
+
+PATTERN="^$TYPE\(.*\)?:"
+
+if [ -z "$(grep -E -i "$PATTERN" "$1")" ]; then
+	for i in $MSG_HISTORY; do
+		if [ -n "$(echo "$i" | grep -E -i "$PATTERN")" ]; then
+			exit 0
+		fi
+	done
+	echo "${RED}Missing commit message with prefix feat/fix. Consider adding one before merging PR for automatic semver release.${NC}"
+fi
+
+exit 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@nosto/web-components",
       "version": "2.2.0",
+      "hasInstallScript": true,
       "devDependencies": {
         "@nosto/nosto-js": "^1.7.0",
         "@types/eslint-config-prettier": "^6.11.3",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "url": "git+https://github.com/Nosto/web-components.git"
   },
   "scripts": {
+    "preinstall": "git config core.hooksPath hooks",
     "build": "tsc && node esbuild.mjs && npm run typedoc",
     "dev": "vite dev",
     "preview": "vite preview",


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
Commit message hook adds a warning during commit about missing conventional commit prefix. It checks the current message or history of messages in current branch for atleast one message with conventional commit prefix. 

Hooks are setup under custom directory and configured in preinstall npm lifecycle script

The hook follows the conventional commit message format described in this documentation https://www.conventionalcommits.org/en/v1.0.0/

It will look at current commit message and the history for messages with following prefixes
1. fix: {YOUR MESSAGE}
2. feat: {YOUR MESSAGE}
3. feat({SCOPE}): {YOUR MESSAGE}
4. fix({SCOPE}): {YOUR MESSAGE}
5. feat({SCOPE})!: {YOUR MESSAGE}
6. fix({SCOPE})!: {YOUR MESSAGE}

The above message prefixes are supported by semver. `!` can be used to indicate critical or breaking change and scope can be any text like api/core/store etc...

When it doesn't find any commit messages with a prefix, a warning message will be displayed during commit. When atleast one found, no messages will be displayed.

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->

<img width="985" alt="Screenshot 2025-04-10 at 15 53 15" src="https://github.com/user-attachments/assets/8bfc3680-1355-4612-afc4-e77f4b87cb87" />


