### PR TITLE
Move init methods back

### DIFF
--- a/src/components/NostoProduct.ts
+++ b/src/components/NostoProduct.ts
@@ -51,26 +51,22 @@ export class NostoProduct extends HTMLElement {
 
   connectedCallback() {
     assertRequired(this, "productId", "recoId")
-    initProduct(this)
+    const store = createStore(this)
+    provideStore(this, store)
+    store.listen("selectedSkuId", selectedSkuId => {
+      this.selectedSkuId = selectedSkuId
+      this.skuSelected = !!selectedSkuId
+    })
+    store.listen("skuImage", image => {
+      this.style.setProperty("--ns-img", `url(${image})`)
+    })
+    store.listen("skuAltImage", altImage => {
+      this.style.setProperty("--ns-alt-img", `url(${altImage})`)
+    })
+    registerSKUSelectors(this, store)
+    registerSKUIds(this, store)
+    registerATCButtons(this, store)
   }
-}
-
-function initProduct(element: NostoProduct) {
-  const store = createStore(element)
-  provideStore(element, store)
-  store.listen("selectedSkuId", selectedSkuId => {
-    element.selectedSkuId = selectedSkuId
-    element.skuSelected = !!selectedSkuId
-  })
-  store.listen("skuImage", image => {
-    element.style.setProperty("--ns-img", `url(${image})`)
-  })
-  store.listen("skuAltImage", altImage => {
-    element.style.setProperty("--ns-alt-img", `url(${altImage})`)
-  })
-  registerSKUSelectors(element, store)
-  registerSKUIds(element, store)
-  registerATCButtons(element, store)
 }
 
 function registerSKUSelectors(element: NostoProduct, { selectSkuId }: Store) {

--- a/src/components/NostoProductCard.ts
+++ b/src/components/NostoProductCard.ts
@@ -50,27 +50,23 @@ export class NostoProductCard extends HTMLElement {
   template!: string
   wrap!: boolean
 
-  connectedCallback() {
+  async connectedCallback() {
     assertRequired(this, "recoId", "template")
-    return initProductCard(this)
-  }
-}
+    this.toggleAttribute("loading", true)
+    const product = getData(this)
+    const html = await evaluate(this.template, { product, data: this.dataset })
 
-async function initProductCard(element: NostoProductCard) {
-  element.toggleAttribute("loading", true)
-  const product = getData(element)
-  const html = await evaluate(element.template, { product, data: element.dataset })
-
-  if (element.wrap) {
-    const wrapper = new NostoProduct()
-    wrapper.recoId = element.recoId
-    wrapper.productId = product.id
-    wrapper.innerHTML = html
-    element.appendChild(wrapper)
-  } else {
-    element.insertAdjacentHTML("beforeend", html)
+    if (this.wrap) {
+      const wrapper = new NostoProduct()
+      wrapper.recoId = this.recoId
+      wrapper.productId = product.id
+      wrapper.innerHTML = html
+      this.appendChild(wrapper)
+    } else {
+      this.insertAdjacentHTML("beforeend", html)
+    }
+    this.toggleAttribute("loading", false)
   }
-  element.toggleAttribute("loading", false)
 }
 
 function getData(element: HTMLElement) {

--- a/src/components/NostoShopify.ts
+++ b/src/components/NostoShopify.ts
@@ -27,16 +27,12 @@ export class NostoShopify extends HTMLElement {
   markets!: boolean
 
   connectedCallback() {
-    initShopify(this)
-  }
-}
-
-function initShopify(element: NostoShopify) {
-  const campaignId = element.closest(".nosto_element")?.id
-  if (!campaignId) {
-    throw new Error("Found no wrapper element with class 'nosto_element'")
-  }
-  if (element.markets) {
-    migrateToShopifyMarket(campaignId)
+    const campaignId = this.closest(".nosto_element")?.id
+    if (!campaignId) {
+      throw new Error("Found no wrapper element with class 'nosto_element'")
+    }
+    if (this.markets) {
+      migrateToShopifyMarket(campaignId)
+    }
   }
 }

--- a/test/components/NostoProductCard.spec.tsx
+++ b/test/components/NostoProductCard.spec.tsx
@@ -11,13 +11,13 @@ describe("NostoProductCard", () => {
   it("should throw an error if recoId is not provided", () => {
     const card = new NostoProductCard()
     card.template = "test"
-    expect(() => card.connectedCallback()).toThrowError("Property recoId is required.")
+    expect(card.connectedCallback()).rejects.toThrowError("Property recoId is required.")
   })
 
   it("should throw an error if template is not provided", () => {
     const card = new NostoProductCard()
     card.recoId = "test"
-    expect(() => card.connectedCallback()).toThrowError("Property template is required.")
+    expect(card.connectedCallback()).rejects.toThrowError("Property template is required.")
   })
 
   it("should render the product", async () => {


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
The extraction of the connectedCallback contents to external functions doesn't decrease the bundle size and also adds unnecessary indirection.

As an alternative the following pattern could work better
* core logic of callback methods is defined in callback methods
* additional logic is defined in top level functions since method names can't be minified

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->