### PR TITLE
fix: use regex for template language match

### DIFF
--- a/src/services/templating.ts
+++ b/src/services/templating.ts
@@ -10,15 +10,13 @@ export async function evaluate(templateId: string, context: object) {
   if (!templateEl) {
     throw new Error(`Template with id "${templateId}" not found.`)
   }
-  switch (templateEl.getAttribute("type")) {
-    case "text/x-liquid-template":
-    case "text/liquid":
-      return evaluateLiquid(templateEl, context)
-    case "text/x-handlebars-template":
-    case "text/handlebars":
-      return evaluateHandlebars(templateEl, context)
-    default:
-      throw new Error(`Unsupported template type "${templateEl.getAttribute("type")}".`)
+  const type = templateEl.getAttribute("type") ?? ""
+  if (/liquid/.test(type)) {
+    return evaluateLiquid(templateEl, context)
+  } else if (/handlebars/.test(type)) {
+    return evaluateHandlebars(templateEl, context)
+  } else {
+    throw new Error(`Unsupported template type "${type}".`)
   }
 }
 


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
Make template language matching more robust by matching the type against a regex instead of specific values

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->