### PR TITLE
feat: add lazy loading support

### DIFF
--- a/test/components/NostoDynamicCard.spec.ts
+++ b/test/components/NostoDynamicCard.spec.ts
@@ -25,6 +25,40 @@ describe("NostoDynamicCard", () => {
     expect(card.innerHTML).toBe(validMarkup)
   })
 
+  it("fetches product lazily when lazy attribute is set", async () => {
+    const validMarkup = "<div>Lazy Loaded Product Info</div>"
+    const fakeResponse = {
+      ok: true,
+      text: vi.fn().mockResolvedValue(validMarkup)
+    }
+    global.fetch = vi.fn().mockResolvedValue(fakeResponse)
+
+    const card = new NostoDynamicCard()
+    card.handle = "lazy-handle"
+    card.template = "default"
+    card.lazy = true
+
+    // Mock IntersectionObserver
+    const mockObserver = {
+      observe: vi.fn(),
+      disconnect: vi.fn()
+    }
+    // @ts-expect-error partial mock assignment
+    global.IntersectionObserver = vi.fn(() => mockObserver)
+
+    // Call connectedCallback manually
+    await card.connectedCallback()
+    expect(mockObserver.observe).toHaveBeenCalledWith(card)
+
+    // Simulate intersection
+    // @ts-expect-error IntersectionObserver is not typed as a mock
+    global.IntersectionObserver.mock.calls[0][0]([{ isIntersecting: true }])
+
+    expect(global.fetch).toHaveBeenCalledWith("/products/lazy-handle?view=default&layout=none")
+    await new Promise(resolve => setTimeout(resolve, 10)) // Wait for async fetch to complete
+    expect(card.innerHTML).toBe(validMarkup)
+  })
+
   it("throws error when fetch response is not ok", async () => {
     const fakeResponse = {
       ok: false,


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
Lazy (viewport visibility) loading for NostoDynamicCard
Useful when NostoDynamicCard is used on e.g. Search or CM2 pages

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->
https://nostosolutions.atlassian.net/browse/CFE-1114

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->