### PR TITLE
fix: move logFirstUsage to superclass

### DIFF
--- a/src/components/NostoCampaign.ts
+++ b/src/components/NostoCampaign.ts
@@ -3,7 +3,7 @@ import { customElement } from "./decorators"
 import { nostojs } from "@nosto/nosto-js"
 import { AttributedCampaignResult, JSONResult } from "@nosto/nosto-js/client"
 import { evaluate } from "@/services/templating"
-import { logFirstUsage } from "@/logger"
+import { NostoElement } from "./NostoElement"
 
 /**
  * A custom element that renders a Nosto campaign based on the provided placement and fetched campaign data.
@@ -20,7 +20,7 @@ import { logFirstUsage } from "@/logger"
  * automatically load the campaign on connection. Defaults to "true".
  */
 @customElement("nosto-campaign")
-export class NostoCampaign extends HTMLElement {
+export class NostoCampaign extends NostoElement {
   static attributes = {
     placement: String,
     productId: String,
@@ -37,9 +37,6 @@ export class NostoCampaign extends HTMLElement {
 
   async connectedCallback() {
     assertRequired(this, "placement")
-
-    logFirstUsage()
-
     if (this.init !== "false") {
       await loadCampaign(this)
     }

--- a/src/components/NostoDynamicCard.ts
+++ b/src/components/NostoDynamicCard.ts
@@ -1,6 +1,6 @@
 import { assertRequired } from "@/utils"
 import { customElement } from "./decorators"
-import { logFirstUsage } from "@/logger"
+import { NostoElement } from "./NostoElement"
 
 /**
  * A custom elements that renders a product by fetching the markup from Shopify based on the provided handle and template.
@@ -21,7 +21,7 @@ import { logFirstUsage } from "@/logger"
  * ```
  */
 @customElement("nosto-dynamic-card")
-export class NostoDynamicCard extends HTMLElement {
+export class NostoDynamicCard extends NostoElement {
   static attributes = {
     handle: String,
     template: String,
@@ -38,7 +38,6 @@ export class NostoDynamicCard extends HTMLElement {
 
   async connectedCallback() {
     assertRequired(this, "handle", "template")
-    logFirstUsage()
     this.toggleAttribute("loading", true)
     if (this.placeholder && placeholders.has(this.template)) {
       this.innerHTML = placeholders.get(this.template) || ""

--- a/src/components/NostoElement.ts
+++ b/src/components/NostoElement.ts
@@ -1,0 +1,8 @@
+import { logFirstUsage } from "@/logger"
+
+export abstract class NostoElement extends HTMLElement {
+  constructor() {
+    super()
+    logFirstUsage()
+  }
+}

--- a/src/components/NostoProduct.ts
+++ b/src/components/NostoProduct.ts
@@ -2,7 +2,7 @@ import { assertRequired } from "@/utils"
 import { createStore, provideStore, Store } from "./NostoProduct/store"
 import { customElement } from "./decorators"
 import { syncSkuData } from "./common"
-import { logFirstUsage } from "@/logger"
+import { NostoElement } from "./NostoElement"
 
 /**
  * Custom element that represents a Nosto product component.
@@ -39,7 +39,7 @@ import { logFirstUsage } from "@/logger"
  *
  */
 @customElement("nosto-product")
-export class NostoProduct extends HTMLElement {
+export class NostoProduct extends NostoElement {
   static attributes = {
     productId: String,
     recoId: String,
@@ -53,7 +53,6 @@ export class NostoProduct extends HTMLElement {
 
   connectedCallback() {
     assertRequired(this, "productId", "recoId")
-    logFirstUsage()
     const store = createStore(this)
     provideStore(this, store)
     addListeners(this, store)

--- a/src/components/NostoProductCard.ts
+++ b/src/components/NostoProductCard.ts
@@ -1,7 +1,7 @@
-import { logFirstUsage } from "@/logger"
 import { customElement } from "./decorators"
 import { evaluate } from "@/services/templating"
 import { assertRequired } from "@/utils"
+import { NostoElement } from "./NostoElement"
 
 /**
  * A custom element that renders a product card based on Nosto recommendation data.
@@ -37,7 +37,7 @@ import { assertRequired } from "@/utils"
  * ```
  */
 @customElement("nosto-product-card")
-export class NostoProductCard extends HTMLElement {
+export class NostoProductCard extends NostoElement {
   static attributes = {
     template: String
   }
@@ -46,7 +46,6 @@ export class NostoProductCard extends HTMLElement {
 
   async connectedCallback() {
     assertRequired(this, "template")
-    logFirstUsage()
     this.toggleAttribute("loading", true)
     const product = getData(this)
     const html = await evaluate(this.template, { product, data: this.dataset })

--- a/src/components/NostoSkuOptions.ts
+++ b/src/components/NostoSkuOptions.ts
@@ -2,7 +2,7 @@ import { assertRequired, intersectionOf } from "@/utils"
 import { injectStore, Store } from "./NostoProduct/store"
 import { customElement } from "./decorators"
 import { syncSkuData } from "./common"
-import { logFirstUsage } from "@/logger"
+import { NostoElement } from "./NostoElement"
 
 /**
  * A custom element that manages SKU (Stock Keeping Unit) options in a product selection interface.
@@ -30,7 +30,7 @@ import { logFirstUsage } from "@/logger"
  * ```
  */
 @customElement("nosto-sku-options")
-export class NostoSkuOptions extends HTMLElement {
+export class NostoSkuOptions extends NostoElement {
   static attributes = {
     name: String
   }
@@ -39,7 +39,6 @@ export class NostoSkuOptions extends HTMLElement {
 
   connectedCallback() {
     assertRequired(this, "name")
-    logFirstUsage()
     injectStore(this, store => initSkuOptions(this, store))
   }
 }


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
As the logging should be applied to all custom elements it makes sense to centralize the logic in a superclass

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->