### PR TITLE
fix: hide attributes from typedoc

### DIFF
--- a/src/components/NostoCampaign/NostoCampaign.ts
+++ b/src/components/NostoCampaign/NostoCampaign.ts
@@ -22,6 +22,7 @@ import { NostoElement } from "../NostoElement"
  */
 @customElement("nosto-campaign")
 export class NostoCampaign extends NostoElement {
+  /** @private */
   static attributes = {
     placement: String,
     productId: String,

--- a/src/components/NostoDynamicCard/NostoDynamicCard.ts
+++ b/src/components/NostoDynamicCard/NostoDynamicCard.ts
@@ -22,6 +22,7 @@ import { NostoElement } from "../NostoElement"
  */
 @customElement("nosto-dynamic-card", { observe: true })
 export class NostoDynamicCard extends NostoElement {
+  /** @private */
   static attributes = {
     handle: String,
     template: String,

--- a/src/components/NostoImage/NostoImage.ts
+++ b/src/components/NostoImage/NostoImage.ts
@@ -35,6 +35,7 @@ import { NostoElement } from "../NostoElement"
  */
 @customElement("nosto-image", { observe: true })
 export class NostoImage extends NostoElement {
+  /** @private */
   static attributes = {
     src: String,
     width: Number,

--- a/src/components/NostoProduct/NostoProduct.ts
+++ b/src/components/NostoProduct/NostoProduct.ts
@@ -40,6 +40,7 @@ import { NostoElement } from "../NostoElement"
  */
 @customElement("nosto-product")
 export class NostoProduct extends NostoElement {
+  /** @private */
   static attributes = {
     productId: String,
     recoId: String,

--- a/src/components/NostoProductCard/NostoProductCard.ts
+++ b/src/components/NostoProductCard/NostoProductCard.ts
@@ -50,6 +50,7 @@ import { getContext } from "../../templating/context"
  */
 @customElement("nosto-product-card")
 export class NostoProductCard extends NostoElement {
+  /** @private */
   static attributes = {
     template: String
   }

--- a/src/components/NostoSkuOptions/NostoSkuOptions.ts
+++ b/src/components/NostoSkuOptions/NostoSkuOptions.ts
@@ -31,6 +31,7 @@ import { NostoElement } from "../NostoElement"
  */
 @customElement("nosto-sku-options")
 export class NostoSkuOptions extends NostoElement {
+  /** @private */
   static attributes = {
     name: String
   }


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
The attributes object is internal metadata used in the customElement decorator and should not be considered as part of the public signature of the custom elements

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->