### PR TITLE
feat: support sections in addition to custom templates

### DIFF
--- a/src/components/NostoDynamicCard/NostoDynamicCard.ts
+++ b/src/components/NostoDynamicCard/NostoDynamicCard.ts
@@ -8,7 +8,8 @@ import { NostoElement } from "../NostoElement"
  * This component is designed to be used in a Shopify environment and fetches product data dynamically.
  *
  * @property {string} handle - The product handle to fetch data for. Required.
- * @property {string} template - The template to use for rendering the product. Required.
+ * @property {string} section - The section to use for rendering the product. section or template is required.
+ * @property {string} template - The template to use for rendering the product. section or template is required.
  * @property {string} [variantId] - The variant ID to fetch specific variant data. Optional.
  * @property {boolean} [placeholder] - If true, the component will display placeholder content while loading. Defaults to false.
  * @property {boolean} [lazy] - If true, the component will only fetch data when it comes into view. Defaults to false.
@@ -24,6 +25,7 @@ import { NostoElement } from "../NostoElement"
 export class NostoDynamicCard extends NostoElement {
   static attributes = {
     handle: String,
+    section: String,
     template: String,
     variantId: String,
     placeholder: Boolean,
@@ -31,7 +33,8 @@ export class NostoDynamicCard extends NostoElement {
   }
 
   handle!: string
-  template!: string
+  section?: string
+  template?: string
   variantId?: string
   placeholder?: boolean
   lazy?: boolean
@@ -45,10 +48,11 @@ export class NostoDynamicCard extends NostoElement {
   }
 
   async connectedCallback() {
-    assertRequired(this, "handle", "template")
+    assertRequired(this, "handle")
     this.toggleAttribute("loading", true)
-    if (this.placeholder && placeholders.has(this.template)) {
-      this.innerHTML = placeholders.get(this.template) || ""
+    const key = this.template || this.section || ""
+    if (this.placeholder && placeholders.has(key)) {
+      this.innerHTML = placeholders.get(key) || ""
     }
     if (this.lazy) {
       const observer = new IntersectionObserver(async entries => {
@@ -70,8 +74,12 @@ const placeholders = new Map<string, string>()
 
 async function getMarkup(element: NostoDynamicCard) {
   const params = new URLSearchParams()
-  params.set("view", element.template)
-  params.set("layout", "none")
+  if (element.template) {
+    params.set("view", element.template)
+    params.set("layout", "none")
+  } else if (element.section) {
+    params.set("section_id", element.section)
+  }
   if (element.variantId) {
     params.set("variant", element.variantId)
   }
@@ -79,8 +87,14 @@ async function getMarkup(element: NostoDynamicCard) {
   if (!result.ok) {
     throw new Error("Failed to fetch product data")
   }
-  const markup = await result.text()
-  placeholders.set(element.template, markup)
+  let markup = await result.text()
+  if (element.section) {
+    const wrapper = document.createElement("div")
+    wrapper.innerHTML = markup.trim()
+    markup = (wrapper.firstChild as HTMLElement)?.innerHTML?.trim()
+  }
+  const key = element.template || element.section || ""
+  placeholders.set(key, markup)
   if (/<(body|html)/.test(markup)) {
     throw new Error(
       `Invalid markup for template ${element.template}, make sure that no <body> or <html> tags are included.`

--- a/test/components/NostoDynamicCard.spec.ts
+++ b/test/components/NostoDynamicCard.spec.ts
@@ -25,6 +25,25 @@ describe("NostoDynamicCard", () => {
     expect(card.innerHTML).toBe(validMarkup)
   })
 
+  it("supports section rendering", async () => {
+    const validMarkup = "<section><div>Product Info</div></section>"
+    const fakeResponse = {
+      ok: true,
+      text: vi.fn().mockResolvedValue(`<section>${validMarkup}</section>`)
+    }
+    global.fetch = vi.fn().mockResolvedValue(fakeResponse)
+
+    const card = new NostoDynamicCard()
+    card.handle = "test-handle"
+    card.section = "product-card"
+
+    // Call connectedCallback manually since it's not automatically triggered in tests.
+    await card.connectedCallback()
+
+    expect(global.fetch).toHaveBeenCalledWith("/products/test-handle?section_id=product-card")
+    expect(card.innerHTML).toBe(validMarkup)
+  })
+
   it("rerenders when attributes change", async () => {
     const validMarkup = "<div>Updated Product Info</div>"
     const fakeResponse = {


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
Add support for section rendering in addition to custom templates
Targeting sections makes it easier for cases where the product card markup is encoded in blocks

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->