### PR TITLE
fix: improve variant preselection logic

### DIFF
--- a/test/components/VariantSelector/VariantSelector.spec.tsx
+++ b/test/components/VariantSelector/VariantSelector.spec.tsx
@@ -528,4 +528,16 @@ describe("VariantSelector", () => {
       expect(variant?.options).toEqual(["Large", "Cotton"])
     })
   })
+
+  it("should preselect options based on given variantId", async () => {
+    addProductHandlers({
+      "variant-test-product": { product: mockProductWithVariants }
+    })
+
+    const selector = (<nosto-variant-selector handle="variant-test-product" variantId={1002} />) as VariantSelector
+    await selector.connectedCallback()
+
+    expect(selector.selectedOptions["Size"]).toBe("Medium")
+    expect(selector.selectedOptions["Color"]).toBe("Blue")
+  })
 })


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
Changes
* add preselection based on given variant-id
* add optional filtering of option values without matching variants (necessary for cases where option values reference variants from other top level products)

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
