### PR TITLE
fix: use property decorators

### DIFF
--- a/src/components/Campaign/Campaign.ts
+++ b/src/components/Campaign/Campaign.ts
@@ -1,4 +1,4 @@
-import { customElement } from "../decorators"
+import { customElement, property } from "../decorators"
 import { nostojs } from "@nosto/nosto-js"
 import { AttributedCampaignResult, JSONResult } from "@nosto/nosto-js/client"
 import { compile } from "@/templating/vue"
@@ -33,24 +33,13 @@ import { addRequest } from "./orchestrator"
  */
 @customElement("nosto-campaign")
 export class Campaign extends NostoElement {
-  /** @private */
-  static properties = {
-    placement: String,
-    productId: String,
-    variantId: String,
-    template: String,
-    init: String,
-    lazy: Boolean,
-    cartSynced: Boolean
-  }
-
-  placement!: string
-  productId?: string
-  variantId?: string
-  template?: string
-  init?: string
-  lazy?: boolean
-  cartSynced?: boolean
+  @property(String) placement!: string
+  @property(String) productId?: string
+  @property(String) variantId?: string
+  @property(String) template?: string
+  @property(String) init?: string
+  @property(Boolean) lazy?: boolean
+  @property(Boolean) cartSynced?: boolean
 
   /** @hidden */
   templateElement?: HTMLTemplateElement

--- a/src/components/DynamicCard/DynamicCard.ts
+++ b/src/components/DynamicCard/DynamicCard.ts
@@ -1,7 +1,7 @@
 import { assertRequired } from "@/utils/assertRequired"
 import { createShopifyUrl } from "@/utils/createShopifyUrl"
 import { getText } from "@/utils/fetch"
-import { customElement } from "../decorators"
+import { customElement, property } from "../decorators"
 import { NostoElement } from "../Element"
 
 /** Event name for the DynamicCard loaded event */
@@ -25,22 +25,12 @@ const DYNAMIC_CARD_LOADED_EVENT = "@nosto/DynamicCard/loaded"
  */
 @customElement("nosto-dynamic-card", { observe: true })
 export class DynamicCard extends NostoElement {
-  /** @private */
-  static properties = {
-    handle: String,
-    section: String,
-    template: String,
-    variantId: String,
-    placeholder: Boolean,
-    lazy: Boolean
-  }
-
-  handle!: string
-  section?: string
-  template?: string
-  variantId?: string
-  placeholder?: boolean
-  lazy?: boolean
+  @property(String) handle!: string
+  @property(String) section?: string
+  @property(String) template?: string
+  @property(String) variantId?: string
+  @property(Boolean) placeholder?: boolean
+  @property(Boolean) lazy?: boolean
 
   async attributeChangedCallback(_: string, oldValue: string | null, newValue: string | null) {
     if (this.isConnected && oldValue !== newValue) {

--- a/src/components/Image/Image.ts
+++ b/src/components/Image/Image.ts
@@ -1,5 +1,5 @@
 import type { Crop, ImageProps } from "./types"
-import { customElement } from "../decorators"
+import { customElement, property } from "../decorators"
 import type { Layout } from "@unpic/core/base"
 import { transform } from "./transform"
 import { NostoElement } from "../Element"
@@ -30,32 +30,17 @@ import { NostoElement } from "../Element"
  */
 @customElement("nosto-image", { observe: true })
 export class Image extends NostoElement {
-  /** @private */
-  static properties = {
-    src: String,
-    width: Number,
-    height: Number,
-    aspectRatio: Number,
-    layout: String,
-    crop: String,
-    alt: String,
-    sizes: String,
-    breakpoints: Array,
-    unstyled: Boolean,
-    fetchpriority: String
-  }
-
-  src!: string
-  width?: number
-  height?: number
-  aspectRatio?: number
-  layout?: Layout
-  crop?: Crop
-  alt?: string
-  sizes?: string
-  breakpoints?: number[]
-  unstyled?: boolean
-  fetchpriority?: "high" | "low" | "auto"
+  @property(String) src!: string
+  @property(Number) width?: number
+  @property(Number) height?: number
+  @property(Number) aspectRatio?: number
+  @property(String) layout?: Layout
+  @property(String) crop?: Crop
+  @property(String) alt?: string
+  @property(String) sizes?: string
+  @property(Array) breakpoints?: number[]
+  @property(Boolean) unstyled?: boolean
+  @property(String) fetchpriority?: "high" | "low" | "auto"
 
   constructor() {
     super()

--- a/src/components/Popup/Popup.ts
+++ b/src/components/Popup/Popup.ts
@@ -1,5 +1,5 @@
 import { nostojs } from "@nosto/nosto-js"
-import { customElement } from "../decorators"
+import { customElement, property } from "../decorators"
 import { NostoElement } from "../Element"
 import styles from "./styles.css?raw"
 import { assertRequired } from "@/utils/assertRequired"
@@ -20,14 +20,8 @@ const setShadowContent = shadowContentFactory(styles)
  */
 @customElement("nosto-popup")
 export class Popup extends NostoElement {
-  /** @private */
-  static properties = {
-    name: String,
-    segment: String
-  }
-
-  name!: string
-  segment?: string
+  @property(String) name!: string
+  @property(String) segment?: string
 
   constructor() {
     super()

--- a/src/components/Product/Product.ts
+++ b/src/components/Product/Product.ts
@@ -1,6 +1,6 @@
 import { assertRequired } from "@/utils/assertRequired"
 import { createStore, injectKey, Store } from "./store"
-import { customElement } from "../decorators"
+import { customElement, property } from "../decorators"
 import { syncSkuData } from "../common"
 import { NostoElement } from "../Element"
 import { provide } from "../inject"
@@ -21,16 +21,9 @@ import { provide } from "../inject"
  */
 @customElement("nosto-product")
 export class Product extends NostoElement {
-  /** @private */
-  static properties = {
-    productId: String,
-    recoId: String,
-    skuSelected: Boolean
-  }
-
-  productId!: string
-  recoId!: string
-  skuSelected?: boolean
+  @property(String) productId!: string
+  @property(String) recoId!: string
+  @property(Boolean) skuSelected?: boolean
 
   /** @hidden */
   selectedSkuId?: string

--- a/src/components/SectionCampaign/SectionCampaign.ts
+++ b/src/components/SectionCampaign/SectionCampaign.ts
@@ -1,7 +1,7 @@
 import { nostojs } from "@nosto/nosto-js"
 import { getText } from "@/utils/fetch"
 import { createShopifyUrl } from "@/utils/createShopifyUrl"
-import { customElement } from "../decorators"
+import { customElement, property } from "../decorators"
 import { NostoElement } from "../Element"
 import { addRequest } from "../Campaign/orchestrator"
 import { JSONResult } from "@nosto/nosto-js/client"
@@ -19,14 +19,8 @@ import { JSONResult } from "@nosto/nosto-js/client"
  */
 @customElement("nosto-section-campaign")
 export class SectionCampaign extends NostoElement {
-  /** @private */
-  static properties = {
-    placement: String,
-    section: String
-  }
-
-  placement!: string
-  section!: string
+  @property(String) placement!: string
+  @property(String) section!: string
 
   async connectedCallback() {
     this.toggleAttribute("loading", true)

--- a/src/components/SimpleCard/SimpleCard.ts
+++ b/src/components/SimpleCard/SimpleCard.ts
@@ -1,7 +1,7 @@
 import { assertRequired } from "@/utils/assertRequired"
 import { createShopifyUrl } from "@/utils/createShopifyUrl"
 import { getJSON } from "@/utils/fetch"
-import { customElement } from "../decorators"
+import { customElement, property } from "../decorators"
 import { NostoElement } from "../Element"
 import type { ShopifyProduct } from "@/shopify/types"
 import { generateCardHTML, updateSimpleCardContent } from "./markup"
@@ -41,22 +41,12 @@ const SIMPLE_CARD_RENDERED_EVENT = "@nosto/SimpleCard/rendered"
  */
 @customElement("nosto-simple-card", { observe: true })
 export class SimpleCard extends NostoElement {
-  /** @private */
-  static properties = {
-    handle: String,
-    alternate: Boolean,
-    brand: Boolean,
-    discount: Boolean,
-    rating: Number,
-    sizes: String
-  }
-
-  handle!: string
-  alternate?: boolean
-  brand?: boolean
-  discount?: boolean
-  rating?: number
-  sizes?: string
+  @property(String) handle!: string
+  @property(Boolean) alternate?: boolean
+  @property(Boolean) brand?: boolean
+  @property(Boolean) discount?: boolean
+  @property(Number) rating?: number
+  @property(String) sizes?: string
 
   product?: JSONProduct
 

--- a/src/components/SkuOptions/SkuOptions.ts
+++ b/src/components/SkuOptions/SkuOptions.ts
@@ -1,7 +1,7 @@
 import { assertRequired } from "@/utils/assertRequired"
 import { intersectionOf } from "@/utils/intersectionOf"
 import { injectKey, Store } from "../Product/store"
-import { customElement } from "../decorators"
+import { customElement, property } from "../decorators"
 import { syncSkuData } from "../common"
 import { NostoElement } from "../Element"
 import { inject } from "../inject"
@@ -28,12 +28,7 @@ import { inject } from "../inject"
  */
 @customElement("nosto-sku-options")
 export class SkuOptions extends NostoElement {
-  /** @private */
-  static properties = {
-    name: String
-  }
-
-  name!: string
+  @property(String) name!: string
 
   connectedCallback() {
     assertRequired(this, "name")

--- a/src/components/VariantSelector/VariantSelector.ts
+++ b/src/components/VariantSelector/VariantSelector.ts
@@ -1,7 +1,7 @@
 import { assertRequired } from "@/utils/assertRequired"
 import { createShopifyUrl } from "@/utils/createShopifyUrl"
 import { getJSON } from "@/utils/fetch"
-import { customElement } from "../decorators"
+import { customElement, property } from "../decorators"
 import { NostoElement } from "../Element"
 import type { ShopifyProduct, ShopifyVariant, VariantChangeDetail } from "@/shopify/types"
 import { generateVariantSelectorHTML } from "./markup"
@@ -35,20 +35,12 @@ const VARIANT_SELECTOR_RENDERED_EVENT = "@nosto/VariantSelector/rendered"
  * @fires variantchange - Emitted when variant selection changes, contains { variant, product }
  * @fires @nosto/VariantSelector/rendered - Emitted when the component has finished rendering
  */
-@customElement("nosto-variant-selector", { observe: true })
+@customElement("nosto-variant-selector")
 export class VariantSelector extends NostoElement {
-  /** @private */
-  static properties = {
-    handle: String,
-    variantId: Number,
-    preselect: Boolean,
-    filtered: Boolean
-  }
-
-  handle!: string
-  variantId?: number
-  preselect?: boolean
-  filtered?: boolean
+  @property(String) handle!: string
+  @property(Number) variantId?: number
+  @property(Boolean) preselect?: boolean
+  @property(Boolean) filtered?: boolean
 
   /**
    * Internal state for current selections

--- a/test/components/decorators.spec.ts
+++ b/test/components/decorators.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { customElement } from "../../src/components/decorators"
+import { customElement, property } from "@/components/decorators"
 
 describe("customElement", () => {
   beforeEach(() => {
@@ -27,21 +27,26 @@ describe("customElement", () => {
     expect(window.customElements.define).toHaveBeenCalledTimes(1)
   })
 
+  it("should update observedAttributes when observe flag is set", () => {
+    const tagName = "my-element-observe"
+    @customElement(tagName, { observe: true })
+    class constructor extends HTMLElement {
+      @property(String) foo!: string
+      @property(Boolean) bar!: boolean
+    }
+
+    // @ts-expect-error type mismatch
+    expect(constructor.observedAttributes).toEqual(["foo", "bar"])
+  })
+
   it("should define properties for attributes", () => {
     const tagName = "my-element3"
     @customElement(tagName)
     class constructor extends HTMLElement {
-      static properties = {
-        foo: String,
-        bar: Boolean,
-        baz: Number,
-        qux: Array
-      }
-
-      foo!: string
-      bar!: boolean
-      baz!: number
-      qux!: number[]
+      @property(String) foo!: string
+      @property(Boolean) bar!: boolean
+      @property(Number) baz!: number
+      @property(Array) qux!: number[]
     }
 
     const e = new constructor()
@@ -60,11 +65,7 @@ describe("customElement", () => {
     const tagName = "my-element4"
     @customElement(tagName)
     class constructor extends HTMLElement {
-      static properties = {
-        numbers: Array
-      }
-
-      numbers!: number[]
+      @property(Array) numbers!: number[]
     }
 
     const e = new constructor()
@@ -95,8 +96,8 @@ describe("customElement", () => {
     expect(e.numbers).toBeUndefined()
 
     // Test removing attribute
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ;(e as any).numbers = undefined
+    // @ts-expect-error type mismatch
+    e.numbers = undefined
     expect(e.hasAttribute("numbers")).toBe(false)
   })
 
@@ -104,11 +105,7 @@ describe("customElement", () => {
     const tagName = "my-element5"
     @customElement(tagName)
     class constructor extends HTMLElement {
-      static properties = {
-        list: Array
-      }
-
-      list!: unknown[]
+      @property(Array) list!: unknown[]
     }
 
     const e = new constructor()


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
Use property decorators to map bi-directional property <> attribute mappings

before

```
    @customElement(tagName)
    class constructor extends HTMLElement {
      static properties = {
        foo: String,
        bar: Boolean,
        baz: Number,
        qux: Array
      }

      foo!: string
      bar!: boolean
      baz!: number
      qux!: number[]
    }
```

after

```
    @customElement(tagName)
    class constructor extends HTMLElement {
      @property(String) foo!: string
      @property(Boolean) bar!: boolean
      @property(Number) baz!: number
      @property(Array) qux!: number[]
    }
```

inspired by lit property decorators https://lit.dev/

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
