### PR TITLE
fix: template selector and add test

### DIFF
--- a/src/components/Campaign/Campaign.ts
+++ b/src/components/Campaign/Campaign.ts
@@ -57,6 +57,10 @@ export class Campaign extends NostoElement {
       throw new Error("placement or id attribute is required for Campaign")
     }
 
+    if (this.placement && !this.id) {
+      this.setAttribute("id", this.placement)
+    }
+
     if (this.cartSynced) {
       const api = await new Promise(nostojs)
       api.listen("cartupdated", this.#load)
@@ -102,7 +106,7 @@ export class Campaign extends NostoElement {
 export async function loadCampaign(element: Campaign) {
   element.toggleAttribute("loading", true)
   try {
-    const useTemplate = element.templateElement || element.template || element.querySelector(":scope > template")
+    const useTemplate = element.templateElement || element.template || element.querySelector("template")
     const placement = element.placement ?? element.id
     const api = await new Promise(nostojs)
 

--- a/src/components/common.ts
+++ b/src/components/common.ts
@@ -20,7 +20,7 @@ export function getTemplate(element: CampaignElement): HTMLTemplateElement {
   }
   const template = element.template
     ? document.querySelector<HTMLTemplateElement>(`template#${element.template}`)
-    : element.querySelector<HTMLTemplateElement>(":scope > template")
+    : element.querySelector<HTMLTemplateElement>("template")
   if (!template) {
     throw new Error(`Template with id "${element.template}" not found.`)
   }

--- a/test/components/Campaign/Campaign.spec.tsx
+++ b/test/components/Campaign/Campaign.spec.tsx
@@ -175,6 +175,14 @@ describe("Campaign", () => {
     expect(mockBuilder.load).not.toHaveBeenCalled()
   })
 
+  it("should mirror id from placement if id is not supplied", async () => {
+    const placementValue = "test-placement"
+    mockNostoRecs({ [placementValue]: {} })
+    const campaign = (<nosto-campaign placement={placementValue} />) as Campaign
+    await campaign.connectedCallback()
+    expect(campaign.id).toBe(placementValue)
+  })
+
   describe("cart-synced functionality", () => {
     let mockListen: Mock
     let mockUnlisten: Mock


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
This pull request introduces improvements to the handling of the `id` attribute in the `Campaign` component, ensuring better consistency and reliability when rendering campaign elements. Additionally, it refines template selection logic to simplify and standardize how templates are queried. The most important changes are grouped below by theme.

**Attribute Handling Improvements:**

* The `Campaign` component now automatically sets its `id` attribute to the value of its `placement` attribute if `id` is not explicitly supplied, ensuring every campaign element has a unique identifier.
* A new test verifies that the `id` is correctly mirrored from `placement` when `id` is not provided, improving test coverage and reliability.

**Template Selection Logic:**

* The template selection logic in both the `loadCampaign` function and the `getTemplate` utility has been updated to use a simpler `element.querySelector("template")` instead of the more complex `:scope > template` selector, making template queries more predictable and easier to maintain. 

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

https://nostosolutions.atlassian.net/browse/NS-13044

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
