### PR TITLE
fix: skip option name prefix

### DIFF
--- a/src/components/VariantSelector/compact/index.ts
+++ b/src/components/VariantSelector/compact/index.ts
@@ -81,8 +81,7 @@ function generateVariantOption(variant: ShopifyVariant, selectedVariantGid: stri
   const variableOptions = variant.selectedOptions?.filter(o => !fixedOptions.includes(o.name)) || []
   let title = variant.title
   if (variableOptions.length === 1) {
-    const { name, value } = variableOptions[0]
-    title = `${name}: ${value}`
+    title = variableOptions[0].value
   } else if (variableOptions.length > 1) {
     title = variableOptions.map(o => o.value).join(" / ")
   }

--- a/test/components/VariantSelector/VariantSelector.compact.spec.tsx
+++ b/test/components/VariantSelector/VariantSelector.compact.spec.tsx
@@ -369,11 +369,11 @@ describe("VariantSelector - Compact Mode", () => {
     expect(options.length).toBe(3) // Small, Medium, Large
 
     // Material is fixed to "Cotton" across all variants, so it should not appear in option text
-    expect(options[0].textContent).toBe("Size: Small")
+    expect(options[0].textContent).toBe("Small")
     expect(options[0].textContent).not.toContain("Cotton")
-    expect(options[1].textContent).toBe("Size: Medium")
+    expect(options[1].textContent).toBe("Medium")
     expect(options[1].textContent).not.toContain("Cotton")
-    expect(options[2].textContent).toBe("Size: Large")
+    expect(options[2].textContent).toBe("Large")
     expect(options[2].textContent).not.toContain("Cotton")
   })
 })


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
Skip option name prefix in VariantSelect compact mode rendering

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
