### PR TITLE
fix: support absolute urls as root

### DIFF
--- a/src/utils/createShopifyUrl.ts
+++ b/src/utils/createShopifyUrl.ts
@@ -9,5 +9,5 @@ export function createShopifyUrl(url: string) {
 // Resolves the root URL of the Shopify store and excludes any query parameters.
 function resolveRootUrl() {
   const root = window.Shopify?.routes?.root ?? "/"
-  return root.match(/https?:\/\//) ? root : `${window.location.origin}${root}`
+  return root.match(/^https?:\/\//) ? root : `${window.location.origin}${root}`
 }


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
Absolute urls are used as Shopify roots in the storybook stories

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
