### PR TITLE
fix: address warning on @fires tag usage

### DIFF
--- a/tsdoc.json
+++ b/tsdoc.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "extends": ["typedoc/tsdoc.json"],
+  "tagDefinitions": [
+    {
+      "tagName": "@fires",
+      "syntaxKind": "block",
+      "allowMultiple": true
+    }
+  ]
+}


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
This pull request adds a new TSDoc configuration file to the project. The configuration extends the default Typedoc settings and introduces support for the `@fires` documentation tag, allowing developers to document events that are fired by functions or classes.

Documentation tooling:

* Added a new `tsdoc.json` configuration file that extends `typedoc/tsdoc.json` and enables the `@fires` tag for documenting emitted events.

As recommended by this documentation https://typedoc.org/documents/Tags.html.

Addresses the error `[warning] Encountered an unknown block tag @fires`

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
