### PR TITLE
feat: migrate to trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
         uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90
         id: semantic
         with:
+          semantic_version: 25.0.2
           extra_plugins: |
             @semantic-release/changelog
             @semantic-release/git
@@ -52,7 +53,6 @@ jobs:
             ]
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPMJS_TOKEN }}
 
   publish-docs:
     needs: release


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
This pull request makes minor updates to the release workflow configuration. The most significant change is the upgrade of the `semantic-release-action` to use semantic version `25.0.2`. Additionally, the environment variable for the npm token has been removed.

Release workflow updates:

* Upgraded the `semantic-release-action` to use `semantic_version: 25.0.2` in `.github/workflows/release.yml`.
* Removed the `NPM_TOKEN` environment variable from the release job in `.github/workflows/release.yml`.

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->
https://nostosolutions.atlassian.net/browse/CFE-1475

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
