### PR TITLE
fix: move deprecated annotation to property level

### DIFF
--- a/src/components/DynamicCard/DynamicCard.ts
+++ b/src/components/DynamicCard/DynamicCard.ts
@@ -29,8 +29,7 @@ let dynamicCardDefaults: DefaultProps = {}
  *
  * @property {string} handle - The product handle to fetch data for. Required.
  * @property {string} section - The section to use for rendering the product. section or template is required.
- * @property {string} template - The template to use for rendering the product. section or template is required.
- * @deprecated Use the `section` property instead. Section Rendering is the recommended approach from Shopify.
+ * @property {string} template - [DEPRECATED] Use {@link section} instead. The template to use for rendering the product. section or template is required.
  * @property {string} [variantId] (`variant-id`) - The variant ID to fetch specific variant data. Optional.
  * @property {boolean} [placeholder] - If true, the component will display placeholder content while loading. Defaults to false.
  * @property {boolean} [lazy] - If true, the component will only fetch data when it comes into view. Defaults to false.
@@ -40,6 +39,7 @@ let dynamicCardDefaults: DefaultProps = {}
 export class DynamicCard extends ReactiveElement {
   @property(String) handle!: string
   @property(String) section?: string
+  /** @deprecated Use the `section` property instead. Section Rendering is the recommended approach from Shopify. */
   @property(String) template?: string
   @property(String) variantId?: string
   @property(Boolean) placeholder?: boolean


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
This pull request makes minor documentation and code annotation updates to the `DynamicCard` component, specifically clarifying the deprecation status of the `template` property and recommending the use of `section` instead.

- Documentation improvements:
  * Updated the JSDoc comment for the `template` property to clearly mark it as deprecated and direct users to use `section` instead.

- Code annotation:
  * Added a `@deprecated` annotation to the `template` property in the class definition, reinforcing the recommendation to use `section`.

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->

### Before:

<img width="1667" height="610" alt="image" src="https://github.com/user-attachments/assets/0dda6480-d8b3-4249-a22e-a7eb75bb9dc2" />

### After:

<img width="1667" height="610" alt="image" src="https://github.com/user-attachments/assets/b8e949f5-fb32-44c6-8da9-055f47656f71" />

<img width="1667" height="610" alt="image" src="https://github.com/user-attachments/assets/139311a7-e262-4cd9-be5d-bc7615baab0e" />


