### PR TITLE
fix(mock): adjust mock data to resemble real data structure

### DIFF
--- a/src/mock/products.ts
+++ b/src/mock/products.ts
@@ -335,6 +335,42 @@ const baseTestProduct: GraphQLProduct = {
       price: { currencyCode: "USD", amount: "19.99" },
       compareAtPrice: null,
       product: { id: "gid://shopify/Product/123456", onlineStoreUrl: "/products/variant-test-product" }
+    },
+    {
+      id: "gid://shopify/ProductVariant/1002",
+      title: "Medium / Blue",
+      availableForSale: true,
+      selectedOptions: [
+        { name: "Size", value: "Medium" },
+        { name: "Color", value: "Blue" }
+      ],
+      price: { currencyCode: "USD", amount: "24.99" },
+      compareAtPrice: null,
+      product: { id: "gid://shopify/Product/123456", onlineStoreUrl: "/products/variant-test-product" }
+    },
+    {
+      id: "gid://shopify/ProductVariant/1003",
+      title: "Large / Red",
+      availableForSale: true,
+      selectedOptions: [
+        { name: "Size", value: "Large" },
+        { name: "Color", value: "Red" }
+      ],
+      price: { currencyCode: "USD", amount: "29.99" },
+      compareAtPrice: null,
+      product: { id: "gid://shopify/Product/123456", onlineStoreUrl: "/products/variant-test-product" }
+    },
+    {
+      id: "gid://shopify/ProductVariant/1004",
+      title: "Small / Green",
+      availableForSale: true,
+      selectedOptions: [
+        { name: "Size", value: "Small" },
+        { name: "Color", value: "Green" }
+      ],
+      price: { currencyCode: "USD", amount: "19.99" },
+      compareAtPrice: null,
+      product: { id: "gid://shopify/Product/123456", onlineStoreUrl: "/products/variant-test-product" }
     }
   ]
 }
@@ -656,6 +692,18 @@ export function getProductWithVariantsMock(productStatus = true, unavailableVari
           { name: "Color", value: "Red" }
         ],
         price: { currencyCode: "USD", amount: "29.99" },
+        compareAtPrice: null,
+        product: { id: "gid://shopify/Product/123456", onlineStoreUrl: "/products/variant-test-product" }
+      },
+      {
+        id: "gid://shopify/ProductVariant/1004",
+        title: "Small / Green",
+        availableForSale: !unavailableVariants.includes("gid://shopify/ProductVariant/1004"),
+        selectedOptions: [
+          { name: "Size", value: "Small" },
+          { name: "Color", value: "Green" }
+        ],
+        price: { currencyCode: "USD", amount: "19.99" },
         compareAtPrice: null,
         product: { id: "gid://shopify/Product/123456", onlineStoreUrl: "/products/variant-test-product" }
       }

--- a/test/components/VariantSelector/VariantSelector.compact.spec.tsx
+++ b/test/components/VariantSelector/VariantSelector.compact.spec.tsx
@@ -52,13 +52,17 @@ describe("VariantSelector - Compact Mode", () => {
     expect(options[0].textContent).toContain("Small / Red")
     expect(options[0].disabled).toBe(false)
 
-    expect(options[1].value).toBe("gid://shopify/ProductVariant/1002")
-    expect(options[1].textContent).toContain("Medium / Blue")
+    expect(options[1].value).toBe("gid://shopify/ProductVariant/1004")
+    expect(options[1].textContent).toContain("Small / Green")
     expect(options[1].disabled).toBe(false)
 
-    expect(options[2].value).toBe("gid://shopify/ProductVariant/1003")
-    expect(options[2].textContent).toContain("Large / Red")
+    expect(options[2].value).toBe("gid://shopify/ProductVariant/1002")
+    expect(options[2].textContent).toContain("Medium / Blue")
     expect(options[2].disabled).toBe(false)
+
+    expect(options[3].value).toBe("gid://shopify/ProductVariant/1003")
+    expect(options[3].textContent).toContain("Large / Red")
+    expect(options[3].disabled).toBe(false)
   })
 
   it("should mark unavailable variants as disabled in compact mode", async () => {
@@ -80,8 +84,8 @@ describe("VariantSelector - Compact Mode", () => {
     const options = dropdown.querySelectorAll("option")
 
     expect(options[0].disabled).toBe(true)
-    expect(options[1].disabled).toBe(false)
-    expect(options[2].disabled).toBe(true)
+    expect(options[1].disabled).toBe(true)
+    expect(options[2].disabled).toBe(false)
     expect(options[3].disabled).toBe(true)
     expect(dropdown).toBeTruthy()
     expect(dropdown.disabled).toBe(false)
@@ -228,9 +232,8 @@ describe("VariantSelector - Compact Mode", () => {
 
     // Expect options to be sorted as Small, Medium, Large based on first option value order
     expect(options[0].textContent).toContain("Small / Red")
-    expect(options[1].textContent).toContain("Medium / Blue")
-    expect(options[2].textContent).toContain("Large / Red")
-    // TODO: Fix this expectation as per the correct order
-    expect(options[3].textContent).toContain("Small / Green")
+    expect(options[1].textContent).toContain("Small / Green")
+    expect(options[2].textContent).toContain("Medium / Blue")
+    expect(options[3].textContent).toContain("Large / Red")
   })
 })


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
Issue with sort order is not an actual issue with the logic but due to mock data.

This pull request expands the mock product data to include a new variant ("Small / Green") and updates the related tests to reflect the new variant and its correct ordering. The main focus is on improving test coverage and ensuring the mock data and tests are consistent with the expected variant order and availability.

**Mock data enhancements:**

* Added a new product variant ("Small / Green") to the `baseTestProduct` mock data in `src/mock/products.ts`, including its selected options, price, and availability.
* Updated the `getProductWithVariantsMock` function in `src/mock/products.ts` to include the "Small / Green" variant and handle its availability status based on input parameters.

**Test updates for variant handling:**

* Modified the variant selector tests in `test/components/VariantSelector/VariantSelector.compact.spec.tsx` to check for the new "Small / Green" variant and verify the correct order and value assignments for all variants.
* Adjusted the tests for disabled state of variants to align with the new variant data and ensure proper handling of unavailable variants.

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
