### PR TITLE
fix: image props width and height to accept null based on storefront types

### DIFF
--- a/src/components/Image/types.ts
+++ b/src/components/Image/types.ts
@@ -1,11 +1,12 @@
-import { ShopifyImage } from "@/shopify/graphql/types"
 import type { CoreImageAttributes, Layout, Operations, UnpicBaseImageProps } from "@unpic/core/base"
 import type { ShopifyOperations } from "unpic/providers/shopify"
 
 export type Crop = Exclude<ShopifyOperations["crop"], undefined>
 
-export type ImageProps = Pick<ShopifyImage, "height" | "width"> & {
+export type ImageProps = {
   src: string
+  width?: number | null
+  height?: number | null
   aspectRatio?: number
   layout?: Layout
   crop?: Crop


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
This pull request makes a small change to the `ImageProps` type definition in `src/components/Image/types.ts` to simplify its structure and improve type safety.

- Refactored the `ImageProps` type to no longer extend `ShopifyImage`, instead explicitly defining `src`, and making `width` and `height` optional and nullable.

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
