### PR TITLE
fix: rating documentation in simple card

### DIFF
--- a/src/components/SimpleCard/SimpleCard.ts
+++ b/src/components/SimpleCard/SimpleCard.ts
@@ -43,7 +43,7 @@ let simpleCardDefaults: DefaultProps = {}
  * @property {string} [imageMode] - Image display mode. Use "alternate" for hover image swap or "carousel" for image carousel with navigation. Defaults to undefined.
  * @property {boolean} [brand] - Show brand/vendor data. Defaults to false.
  * @property {boolean} [discount] - Show discount data. Defaults to false.
- * @property {boolean} [rating] - Show product rating. Defaults to false.
+ * @property {number} [rating] - Product rating value. Displays star rating if set. Defaults to undefined.
  * @property {string} [imageSizes] - The sizes attribute for responsive images to help the browser choose the right image size.
  * @property {boolean} [mock] - If true, uses mock data instead of fetching from Shopify. Defaults to false.
  *


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
This pull request makes a small update to the documentation for the `SimpleCard` component props. The change clarifies the type and usage of the `rating` property, specifying that it is now a number representing the product rating value and will display a star rating if set.

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
