### PR TITLE
[codex] Add sync attributes to SectionCampaign

### DIFF
--- a/src/components/SectionCampaign/SectionCampaign.ts
+++ b/src/components/SectionCampaign/SectionCampaign.ts
@@ -5,6 +5,7 @@ import { customElement, property } from "../decorators"
 import { NostoElement } from "../Element"
 import { addRequest } from "../Campaign/orchestrator"
 import { JSONResult } from "@nosto/nosto-js/client"
+import { isNavigationApiSupported } from "@/utils/navigationApi"
 
 /**
  * A custom element that fetches Nosto placement results and renders them using Shopify section templates.
@@ -17,14 +18,51 @@ import { JSONResult } from "@nosto/nosto-js/client"
  * @property {string} placement - The placement identifier for the campaign.
  * @property {string} section - The section to be used for Section Rendering API based rendering.
  * @property {string} [titleSelector] - CSS selector for the title element to inject the campaign title (attribute: "title-selector").
+ * @property {boolean} [cartSynced] (`cart-synced`) - If true, the component will reload the campaign
+ * whenever a cart update event occurs. Useful for keeping cart-related campaigns in sync
+ * with cart changes. Defaults to false.
+ * @property {boolean} [navSynced] (`nav-synced`) - If true, the component will reload the campaign
+ * whenever a successful page navigation occurs via the Navigation API. Useful for keeping
+ * campaigns in sync with URL changes (e.g., category-specific recommendations). Requires
+ * browser support for the Navigation API. Defaults to false.
  */
 @customElement("nosto-section-campaign")
 export class SectionCampaign extends NostoElement {
   @property(String) placement!: string
   @property(String) section!: string
   @property(String) titleSelector?: string
+  @property(Boolean) cartSynced?: boolean
+  @property(Boolean) navSynced?: boolean
+
+  #load = this.load.bind(this)
 
   async connectedCallback() {
+    if (this.cartSynced) {
+      const api = await new Promise(nostojs)
+      api.listen("cartupdated", this.#load)
+    }
+    if (this.navSynced) {
+      if (isNavigationApiSupported()) {
+        navigation.addEventListener("navigatesuccess", this.#load)
+      } else {
+        console.warn("Navigation API is not supported in this browser. The nav-synced feature will not work.")
+      }
+    }
+
+    await this.load()
+  }
+
+  async disconnectedCallback() {
+    if (this.cartSynced) {
+      const api = await new Promise(nostojs)
+      api.unlisten("cartupdated", this.#load)
+    }
+    if (this.navSynced && isNavigationApiSupported()) {
+      navigation.removeEventListener("navigatesuccess", this.#load)
+    }
+  }
+
+  async load() {
     this.toggleAttribute("loading", true)
     try {
       await this.#initializeMarkup()

--- a/test/components/SectionCampaign/SectionCampaign.spec.tsx
+++ b/test/components/SectionCampaign/SectionCampaign.spec.tsx
@@ -1,7 +1,8 @@
 /** @jsx createElement */
-import { describe, it, expect, Mock } from "vitest"
+import { describe, it, expect, Mock, vi, beforeEach, afterEach } from "vitest"
 import { SectionCampaign } from "@/components/SectionCampaign/SectionCampaign"
 import { RequestBuilder } from "@nosto/nosto-js/client"
+import { mockNostojs, restoreNostojs } from "@nosto/nosto-js/testing"
 import { addHandlers } from "../../msw.setup"
 import { http, HttpResponse } from "msw"
 import { mockNostoRecs } from "../../mockNostoRecs"
@@ -265,5 +266,130 @@ describe("SectionCampaign", () => {
     expect(el.innerHTML).toContain("Should Not Change")
     expect(attributeProductClicksInCampaign).toHaveBeenCalledWith(el, { products, title: "Custom Title" })
     expect(el.hasAttribute("loading")).toBe(false)
+  })
+
+  describe("cart-synced functionality", () => {
+    let mockListen: Mock
+    let mockUnlisten: Mock
+
+    beforeEach(() => {
+      mockListen = vi.fn()
+      mockUnlisten = vi.fn()
+    })
+
+    afterEach(() => {
+      restoreNostojs()
+      vi.restoreAllMocks()
+    })
+
+    it("registers cart update listener when cart-synced is true", async () => {
+      mockNostojs({
+        listen: mockListen,
+        unlisten: mockUnlisten
+      })
+      vi.spyOn(SectionCampaign.prototype, "load").mockResolvedValue(undefined)
+
+      const el = (
+        <nosto-section-campaign placement="placement1" section="featured-section" cart-synced />
+      ) as SectionCampaign
+
+      await el.connectedCallback()
+
+      expect(mockListen).toHaveBeenCalledWith("cartupdated", expect.any(Function))
+    })
+
+    it("reloads campaign when cart update event is triggered", async () => {
+      mockNostojs({
+        listen: mockListen,
+        unlisten: mockUnlisten
+      })
+      const loadSpy = vi.spyOn(SectionCampaign.prototype, "load").mockResolvedValue(undefined)
+
+      const el = (
+        <nosto-section-campaign placement="placement1" section="featured-section" cart-synced={true} />
+      ) as SectionCampaign
+
+      await el.connectedCallback()
+
+      const cartUpdateCallback = mockListen.mock.calls[0][1]
+      await cartUpdateCallback()
+
+      expect(loadSpy).toHaveBeenCalledTimes(2)
+
+      await el.disconnectedCallback()
+
+      expect(mockUnlisten).toHaveBeenCalledWith("cartupdated", expect.any(Function))
+    })
+  })
+
+  describe("nav-synced functionality", () => {
+    let mockNavigation: {
+      addEventListener: Mock
+      removeEventListener: Mock
+    }
+
+    beforeEach(() => {
+      mockNavigation = {
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn()
+      }
+      // @ts-expect-error partial mock assignment
+      global.navigation = mockNavigation
+    })
+
+    afterEach(() => {
+      // @ts-expect-error cleanup
+      delete global.navigation
+      vi.restoreAllMocks()
+    })
+
+    it("registers navigation listener when nav-synced is true", async () => {
+      vi.spyOn(SectionCampaign.prototype, "load").mockResolvedValue(undefined)
+
+      const el = (
+        <nosto-section-campaign placement="placement1" section="featured-section" nav-synced />
+      ) as SectionCampaign
+
+      await el.connectedCallback()
+
+      expect(mockNavigation.addEventListener).toHaveBeenCalledWith("navigatesuccess", expect.any(Function))
+    })
+
+    it("does not register navigation listener when Navigation API is not supported", async () => {
+      // @ts-expect-error cleanup
+      delete global.navigation
+
+      const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+      vi.spyOn(SectionCampaign.prototype, "load").mockResolvedValue(undefined)
+
+      const el = (
+        <nosto-section-campaign placement="placement1" section="featured-section" nav-synced />
+      ) as SectionCampaign
+
+      await el.connectedCallback()
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "Navigation API is not supported in this browser. The nav-synced feature will not work."
+      )
+    })
+
+    it("reloads campaign when navigation success event is triggered", async () => {
+      const loadSpy = vi.spyOn(SectionCampaign.prototype, "load").mockResolvedValue(undefined)
+
+      const el = (
+        <nosto-section-campaign placement="placement1" section="featured-section" nav-synced={true} />
+      ) as SectionCampaign
+
+      await el.connectedCallback()
+
+      const navigationCallback = mockNavigation.addEventListener.mock.calls[0][1]
+      await navigationCallback()
+
+      expect(loadSpy).toHaveBeenCalledTimes(2)
+
+      await el.disconnectedCallback()
+
+      expect(mockNavigation.removeEventListener).toHaveBeenCalledWith("navigatesuccess", expect.any(Function))
+    })
   })
 })


### PR DESCRIPTION
## What changed

- Added `cart-synced` and `nav-synced` boolean attributes to `nosto-section-campaign`.
- Reused the same cart update and Navigation API listener behavior as `nosto-campaign`.
- Added focused regression tests for listener registration, reload callbacks, cleanup, and unsupported Navigation API warnings.

## Why

`SectionCampaign` should support the same sync attributes as `Campaign`, so section-rendered campaigns can refresh after cart updates and successful client-side navigations.

## Validation

- `npm run typecheck`
- `npx eslint src/components/SectionCampaign/SectionCampaign.ts test/components/SectionCampaign/SectionCampaign.spec.tsx`
- `PATH=/Users/timo.westkamper/.nvm/versions/node/v24.11.1/bin:$PATH npx vitest run --silent=true test/components/SectionCampaign/SectionCampaign.spec.tsx test/components/Campaign/Campaign.spec.tsx`
