### PR TITLE
[codex] Remove npm audit from GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Audit dependencies
-        run: npm audit --audit-level=high
-
       - name: Build project
         run: npm run build
 
@@ -42,9 +39,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Audit dependencies
-        run: npm audit --audit-level=high
-
       - name: Run lint
         run: npm run lint
 
@@ -61,9 +55,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Audit dependencies
-        run: npm audit --audit-level=high
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Audit dependencies
-        run: npm audit --audit-level=high
-
       - name: Run build
         run: npm run build
 
@@ -82,9 +79,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Audit dependencies
-        run: npm audit --audit-level=high
 
       - name: Build TypeDoc documentation
         run: npm run build


### PR DESCRIPTION
## Summary

- Removed npm audit --audit-level=high steps from CI build, lint, and Storybook test jobs.
- Removed npm audit --audit-level=high steps from release and docs publishing workflows.

## Impact

Workflow jobs still install dependencies and continue with their existing build, lint, test, Storybook, documentation, and release steps without running npm audit in GitHub Actions.

## Validation

- Searched .github/workflows for remaining audit invocations; none found.